### PR TITLE
Extra comma removed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -54,7 +54,7 @@
     "iso-currency": "~0.2.0",
     "titatoggle": "~1.2.6",
     "elementQuery": "https://github.com/TomekSzymanski/elementQuery.git",
-    "angular-touch": "1.3.16",
+    "angular-touch": "1.3.16"
   },
   "resolutions": {
     "angular": "1.3.x",


### PR DESCRIPTION
The comma was causing bower to throw an error on initial installation.